### PR TITLE
fix: correct repository URL and remove git plugin for branch protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/brajkovic/containerfile-ts.git"
+    "url": "https://github.com/bojanrajkovic/containerfile-ts.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Two fixes to make semantic-release work correctly with branch protection:

1. **Fix repository URL**: Changed from `github.com/brajkovic/containerfile-ts.git` to `github.com/bojanrajkovic/containerfile-ts.git`
2. **Remove git plugin**: Removed `@semantic-release/git` to avoid conflicts with branch protection on main

## Why remove the git plugin?

The `@semantic-release/git` plugin tries to commit CHANGELOG.md back to the repository, which requires pushing to the protected main branch. Without creating a custom GitHub App with bypass permissions (complex setup), the simpler solution is to remove this plugin.

**What still works:**
- ✅ Changelog generated and included in GitHub Releases
- ✅ Git tags created for each release
- ✅ npm publishing with provenance
- ✅ GitHub Releases with full release notes

**What changes:**
- ❌ CHANGELOG.md won't be committed to the repository (only visible in GitHub Releases)

This is a recommended pattern for semantic-release with protected branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)