### PR TITLE
ci: scope security audit to production dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,12 @@ jobs:
         run: pnpm build
 
       - name: Security audit
-        run: pnpm audit --audit-level=moderate
+        # Scope to production deps only: this is a published library, so dev/release
+        # tooling (changesets, lint-staged, tsx, etc.) is never shipped to consumers.
+        # Auditing the full tree flags transitive advisories in build tooling that
+        # pose no risk to package consumers and cannot be remediated without breaking
+        # the tooling (e.g. js-yaml's only patched version drops an API changesets needs).
+        run: pnpm audit --prod --audit-level=moderate
 
       - name: Verify package signatures
         run: pnpm audit signatures


### PR DESCRIPTION
The `pnpm audit --audit-level=moderate` CI step audited the full dependency tree, including dev/release tooling (`@changesets/cli`, `lint-staged`, `tsx`). A batch of newly-published advisories there — [js-yaml](https://github.com/advisories/GHSA-h67p-54hq-rp68), [picomatch](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj), [esbuild](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr) — began failing CI on **every** open branch at once. The failure was external to the PRs, not anything they changed, and none of those packages ship in the published library.

Scope the audit to `--prod` so it covers only the runtime deps consumers receive (`@sinclair/typebox`, `neverthrow`). The patched js-yaml (4.1.2) is a breaking major bump that drops the `safeLoad` API `read-yaml-file` depends on, so an `overrides` pin isn't viable.

The `Verify package signatures` step (`pnpm audit signatures` — real ECDSA registry signature verification on pnpm 11) is unaffected and kept as-is.

Verified locally: `pnpm audit --prod --audit-level=moderate` → "No known vulnerabilities found".